### PR TITLE
Implement Penrose tiling generation and export grids

### DIFF
--- a/src/screensaver.py
+++ b/src/screensaver.py
@@ -1,20 +1,17 @@
-"""Generate a slowly refreshing Ammann–Beenker maze animation for 540×960 e-paper.
+"""Generate a slowly refreshing Penrose maze animation for 540×960 e-paper.
 
-The routine below builds an Ammann–Beenker tiling patch via the standard
-cut-and-project construction, stitches its vertex set into a single
-randomised Hamiltonian-style cycle using a nearest-neighbour/2-opt tour,
-and renders the incremental drawing to a 16-level grayscale GIF sized for
-an M5 PaperS3 panel. Each frame is delayed by ~10 seconds by default so the
-loop animates at an e-paper friendly cadence.
+The routine below constructs a Penrose rhombus tiling using de Bruijn's
+pentagrid method, stitches its vertex set into a single Hamiltonian-style
+cycle via a nearest-neighbour/2-opt tour, and renders a static preview that
+can be used for GIF generation on the target device. The same pentagrid is
+also exported as PNG overlays to aid debugging and artistic exploration.
 """
 from __future__ import annotations
 
 import argparse
-import itertools
 import logging
 import math
 import random
-import time
 from pathlib import Path
 from typing import Iterable, Iterator, List, Sequence, Tuple
 
@@ -47,60 +44,166 @@ def build_palette_image() -> Image.Image:
 PALETTE_IMAGE = build_palette_image()
 
 
-def generate_ab_patch(limit: int, window: float, rng: random.Random) -> List[Tuple[float, float]]:
-    """Generate vertex coordinates for an Ammann–Beenker tiling patch."""
-    angles = [index * math.pi / 4 for index in range(4)]
-    physical = [(math.cos(angle), math.sin(angle)) for angle in angles]
-    perpendicular = [
-        (math.cos(angle + math.pi / 2), math.sin(angle + math.pi / 2)) for angle in angles
-    ]
+def _build_penrose_basis() -> List[Tuple[float, float]]:
+    """Return the five unit vectors used for the Penrose pentagrid basis."""
+    basis: List[Tuple[float, float]] = []
+    for index in range(5):
+        angle = 2 * math.pi * index / 5.0
+        basis.append((math.cos(angle), math.sin(angle)))
+    return basis
 
-    coords: List[Tuple[float, float]] = []
-    for vector in itertools.product(range(-limit, limit + 1), repeat=4):
-        x = y = u = v = 0.0
-        for coefficient, (px, py), (qx, qy) in zip(vector, physical, perpendicular):
-            x += coefficient * px
-            y += coefficient * py
-            u += coefficient * qx
-            v += coefficient * qy
-        if max(abs(u), abs(v)) <= window:
-            coords.append((x, y))
 
-    if not coords:
-        raise ValueError("No tiling vertices were generated; adjust --limit/--window")
+def _apply_scaling(
+    points: Iterable[Tuple[float, float]],
+    width: int,
+    height: int,
+    margin: int,
+) -> Tuple[List[Tuple[float, float]], Tuple[float, float, float, float]]:
+    """Scale an iterable of points to fill the drawing rectangle with padding."""
 
-    # Apply a random dihedral-8 symmetry to keep runs varied.
-    # Restrict the rotation to multiples of 90° so the patch stays axis aligned.
-    theta = rng.randrange(4) * math.pi / 2
-    sin_theta = math.sin(theta)
-    cos_theta = math.cos(theta)
-    flipped = rng.choice([False, True])
+    xs = [x for x, _ in points]
+    ys = [y for _, y in points]
+    if not xs or not ys:
+        raise ValueError("Penrose generator produced no vertices")
 
-    transformed: List[Tuple[float, float]] = []
-    for x, y in coords:
-        if flipped:
-            x = -x
-        tx = x * cos_theta - y * sin_theta
-        ty = x * sin_theta + y * cos_theta
-        transformed.append((tx, ty))
-
-    xs = [x for x, _ in transformed]
-    ys = [y for _, y in transformed]
     min_x, max_x = min(xs), max(xs)
     min_y, max_y = min(ys), max(ys)
     span_x = max_x - min_x
     span_y = max_y - min_y
     if span_x == 0 or span_y == 0:
-        raise ValueError("Degenerate patch dimensions detected")
+        raise ValueError("Degenerate Penrose patch dimensions detected")
 
-    # --- Aspect ratio fix ---
-    # Instead of uniform scaling, stretch to fill the rectangle
-    scale_x = (WIDTH - 2 * MARGIN) / span_x
-    scale_y = (HEIGHT - 2 * MARGIN) / span_y
-    offset_x = MARGIN - scale_x * min_x
-    offset_y = MARGIN - scale_y * min_y
+    scale_x = (width - 2 * margin) / span_x
+    scale_y = (height - 2 * margin) / span_y
+    offset_x = margin - scale_x * min_x
+    offset_y = margin - scale_y * min_y
 
-    return [(scale_x * x + offset_x, scale_y * y + offset_y) for x, y in transformed]
+    scaled = [(scale_x * x + offset_x, scale_y * y + offset_y) for x, y in points]
+    return scaled, (scale_x, scale_y, offset_x, offset_y)
+
+
+def _safe_mod(value: float) -> float:
+    """Return a fractional offset constrained to (0, 1)."""
+
+    frac = value % 1.0
+    eps = 1e-6
+    if frac < eps:
+        frac += eps
+    if frac > 1.0 - eps:
+        frac -= eps
+    return frac
+
+
+def generate_penrose_patch(
+    limit: int,
+    offset_phase: float,
+) -> Tuple[List[Tuple[float, float]], List[List[Tuple[Tuple[float, float], Tuple[float, float]]]]]:
+    """Generate vertex coordinates and grid segments for a Penrose tiling patch."""
+
+    if limit < 1:
+        raise ValueError("--limit must be at least 1 for Penrose tiling generation")
+
+    basis = _build_penrose_basis()
+    gammas = [_safe_mod(offset_phase + index / 5.0) for index in range(5)]
+
+    index_range = range(-limit, limit + 1)
+    vertices: dict[Tuple[int, int, int, int, int], Tuple[float, float]] = {}
+    grid_indices = [set() for _ in range(5)]
+
+    def solve_intersection(i: int, j: int, ki: int, kj: int) -> Tuple[float, float] | None:
+        ei_x, ei_y = basis[i]
+        ej_x, ej_y = basis[j]
+        ci = ki + gammas[i]
+        cj = kj + gammas[j]
+        det = ei_x * ej_y - ei_y * ej_x
+        if abs(det) < 1e-12:
+            return None
+        x = (ci * ej_y - cj * ei_y) / det
+        y = (ei_x * cj - ej_x * ci) / det
+        return x, y
+
+    for i in range(5):
+        for j in range(i + 1, 5):
+            for ki in index_range:
+                for kj in index_range:
+                    intersection = solve_intersection(i, j, ki, kj)
+                    if intersection is None:
+                        continue
+                    x, y = intersection
+                    base_indices = []
+                    for idx, (bx, by) in enumerate(basis):
+                        value = bx * x + by * y - gammas[idx]
+                        base_indices.append(int(math.ceil(value - 1e-9)))
+
+                    for di in (0, 1):
+                        for dj in (0, 1):
+                            key_list = list(base_indices)
+                            key_list[i] += di
+                            key_list[j] += dj
+                            key = tuple(key_list)  # type: ignore[assignment]
+                            px = sum(key_list[idx] * basis[idx][0] for idx in range(5))
+                            py = sum(key_list[idx] * basis[idx][1] for idx in range(5))
+                            vertices.setdefault(key, (px, py))
+
+                    grid_indices[i].add(ki)
+                    grid_indices[j].add(kj)
+
+    if not vertices:
+        raise ValueError("Penrose generator produced no vertices; increase --limit")
+
+    sorted_keys = sorted(vertices.keys())
+    raw_points = [vertices[key] for key in sorted_keys]
+    scaled_points, transform = _apply_scaling(raw_points, WIDTH, HEIGHT, MARGIN)
+    scale_x, scale_y, offset_x, offset_y = transform
+
+    def apply_transform(point: Tuple[float, float]) -> Tuple[float, float]:
+        return (point[0] * scale_x + offset_x, point[1] * scale_y + offset_y)
+
+    bounds = (
+        min(x for x, _ in raw_points) - 1.0,
+        max(x for x, _ in raw_points) + 1.0,
+        min(y for _, y in raw_points) - 1.0,
+        max(y for _, y in raw_points) + 1.0,
+    )
+
+    def clip_line(
+        normal: Tuple[float, float],
+        constant: float,
+    ) -> Tuple[Tuple[float, float], Tuple[float, float]] | None:
+        nx, ny = normal
+        x_min, x_max, y_min, y_max = bounds
+        intersections: List[Tuple[float, float]] = []
+        if abs(ny) > 1e-12:
+            for x_edge in (x_min, x_max):
+                y_val = (constant - nx * x_edge) / ny
+                if y_min - 1e-9 <= y_val <= y_max + 1e-9:
+                    intersections.append((x_edge, y_val))
+        if abs(nx) > 1e-12:
+            for y_edge in (y_min, y_max):
+                x_val = (constant - ny * y_edge) / nx
+                if x_min - 1e-9 <= x_val <= x_max + 1e-9:
+                    intersections.append((x_val, y_edge))
+
+        unique: List[Tuple[float, float]] = []
+        for candidate in intersections:
+            if not any(math.hypot(candidate[0] - pt[0], candidate[1] - pt[1]) < 1e-6 for pt in unique):
+                unique.append(candidate)
+            if len(unique) == 2:
+                break
+        if len(unique) < 2:
+            return None
+        return apply_transform(unique[0]), apply_transform(unique[1])
+
+    grid_segments: List[List[Tuple[Tuple[float, float], Tuple[float, float]]]] = [[] for _ in range(5)]
+    for index in range(5):
+        normal = basis[index]
+        for ki in sorted(grid_indices[index]):
+            constant = ki + gammas[index]
+            segment = clip_line(normal, constant)
+            if segment is not None:
+                grid_segments[index].append(segment)
+
+    return scaled_points, grid_segments
 
 
 def nearest_neighbour_cycle(points: Sequence[Tuple[float, float]], rng: random.Random) -> List[int]:
@@ -216,19 +319,47 @@ def render_static(
     return image
 
 
+def render_pentagrid_overlay(
+    grid_segments: Sequence[Sequence[Tuple[Tuple[float, float], Tuple[float, float]]]],
+    output_path: Path,
+) -> Image.Image:
+    """Render the five Penrose grids as coloured line overlays."""
+
+    palette = [
+        (220, 70, 60),
+        (60, 150, 220),
+        (70, 200, 120),
+        (220, 170, 60),
+        (180, 90, 220),
+    ]
+    image = Image.new("RGB", (WIDTH, HEIGHT), color=(255, 255, 255))
+    draw = ImageDraw.Draw(image)
+    for index, segments in enumerate(grid_segments):
+        color = palette[index % len(palette)]
+        for start, end in segments:
+            draw.line((*start, *end), fill=color, width=1)
+    image.save(output_path)
+    return image
+
+
 def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--limit", type=int, default=7, help="Cut-and-project search radius (default: 7)")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=5,
+        help="Pentagrid index radius controlling the Penrose patch size (default: 5)",
+    )
     parser.add_argument(
         "--window",
         type=float,
-        default=1.6,
-        help="Acceptance window radius in perpendicular space (default: 1.6)",
+        default=0.6,
+        help="Phase offset applied to the pentagrid shifts (default: 0.6)",
     )
     parser.add_argument(
         "--two-opt-rounds",
         type=int,
-        default=48,
+        default=16,
         help="Maximum number of 2-opt refinement sweeps applied to the tour",
     )
     parser.add_argument(
@@ -296,10 +427,17 @@ def main(argv: Sequence[str] | None = None) -> None:
     logging.info("Screensaver tool started.")
     args = parse_args(argv)
     rng = random.Random(args.seed)
-    logging.info(f"Generating Ammann–Beenker patch (limit={args.limit}, window={args.window})")
+    logging.info(
+        "Generating Penrose pentagrid patch (limit=%s, phase=%.3f)",
+        args.limit,
+        args.window,
+    )
     try:
-        points = generate_ab_patch(limit=args.limit, window=args.window, rng=rng)
-        logging.info(f"Generated {len(points)} vertices.")
+        points, grid_segments = generate_penrose_patch(
+            limit=args.limit,
+            offset_phase=args.window,
+        )
+        logging.info("Generated %d Penrose vertices.", len(points))
         logging.info(f"Building Hamiltonian cycle with {args.two_opt_rounds} two-opt rounds.")
         cycle = build_cycle(points, rng=rng, two_opt_rounds=args.two_opt_rounds)
         logging.info(f"Cycle constructed with {len(cycle)} points.")
@@ -308,6 +446,7 @@ def main(argv: Sequence[str] | None = None) -> None:
         cycle_level = 15
         background_level = 0
         output_path = args.gif.with_suffix(".png")
+        output_path.parent.mkdir(parents=True, exist_ok=True)
         logging.info(f"Rendering static image to {output_path}")
         render_static(
             points=points,
@@ -318,6 +457,9 @@ def main(argv: Sequence[str] | None = None) -> None:
             line_width=args.line_width,
             output_path=output_path,
         )
+        grid_output_path = output_path.with_name(f"{output_path.stem}_pentagrid.png")
+        logging.info("Rendering pentagrid overlay to %s", grid_output_path)
+        render_pentagrid_overlay(grid_segments=grid_segments, output_path=grid_output_path)
         logging.info("Static image rendering complete.")
     except Exception as e:
         logging.error(f"Error: {e}")


### PR DESCRIPTION
## Summary
- replace the Ammann–Beenker cut-and-project routine with a Penrose pentagrid generator that yields scaled vertices and grid segments
- add a pentagrid overlay renderer and adjust CLI defaults for the new orderly tiling
- emit a pentagrid PNG alongside the main static render when producing GIF assets

## Testing
- python src/screensaver.py --dry-run --seed 1

------
https://chatgpt.com/codex/tasks/task_e_68cb320abb90832c8efb97ffb18aa2fd